### PR TITLE
Make GatewayReceiver write correct response body

### DIFF
--- a/PSWin.Client/LinkMobility.PSWin.Client.csproj
+++ b/PSWin.Client/LinkMobility.PSWin.Client.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <Authors>Link Mobility NE</Authors>
     <Company></Company>
     <Description>Send SMS through PSWin gateway.</Description>

--- a/PSWin.Receiver/LinkMobility.PSWin.Receiver.csproj
+++ b/PSWin.Receiver/LinkMobility.PSWin.Receiver.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.1.0</Version>
+    <Version>1.3.0</Version>
     <Company></Company>
     <Authors>Link Mobility NE</Authors>
     <Description>Receive mobile originated messages and delivery reports from PSWin gateway.</Description>


### PR DESCRIPTION
We weren't returning the correct response when the GatewayReceiver received a MO or DR request. The response was also not written to the HttpContext in the right way.